### PR TITLE
📚 DOCS:: Update for dropdown class

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,25 +31,26 @@ extensions = [
 ]
 ```
 Now, whenever you wish for an admonition to be toggle-able, add the
-`:class: toggle` parameter to the admonition directive that you use.
+`:class: dropdown` parameter to the admonition directive that you use.
 
-For example, this code would create a toggle-able "note" admonition:
+For example, this code would create a toggle-able "note" admonition
+that starts hidden:
 
 ```rst
 .. note::
-    :class: toggle
+    :class: dropdown
 
     This is my note.
 ```
 
 Clicking on the toggle button will toggle the item's visibility.
 
-You may also **hide the content by default**. To do so, add the `toggle`
-class *as well as* a `toggle-hidden` class, like so:
+You may also **show the content by default**. To do so, add the `dropdown`
+class *as well as* a `toggle-shown` class, like so:
 
 ```rst
 .. note::
-    :class: toggle, toggle-hidden
+    :class: dropdown, toggle-shown
 
     This is my note.
 ```


### PR DESCRIPTION
- I was trying to use this extension, and got confused because the
  readme wasn't updated for the new `dropdown` class and
  `toggle-shown` semantics (as opposed to being shown by default with
  toggle-hidden as an option).  Ref: 8cebb39ea5, #13
- I fixed it to save others some time, since this took quite a while
  to figure out...
- Review: make sure it's correct, I didn't miss anywhere, this is what
  the future is.
  - also fix the "container" part at the bottom - should this be
    updated to the toggle directive or is that still true?