### PR TITLE
📚 DOCS: Disable pygments_style setting

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,7 +65,7 @@ language = None
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = "sphinx"
+#pygments_style = "sphinx"
 
 
 # -- Options for HTML output -------------------------------------------------


### PR DESCRIPTION
The style provided by the HTML theme should be fine.