### PR TITLE
IMPROVE: Allow clicking on whole admonition title

### DIFF
--- a/sphinx_togglebutton/_static/togglebutton.css_t
+++ b/sphinx_togglebutton/_static/togglebutton.css_t
@@ -1,5 +1,5 @@
 /* Visibility of the target */
-.toggle, div.admonition.toggle .admonition-title ~ * {
+.toggle, .admonition.toggle .admonition-title ~ * {
     transition: opacity .5s, height .5s;
 }
 
@@ -14,12 +14,12 @@
 /* Overrides for admonition toggles */
 
 /* Titles should cut off earlier to avoid overlapping w/ button */
-div.admonition.toggle p.admonition-title {
+.admonition.toggle p.admonition-title {
     padding-right: 25%;
 }
 
 /* hides all the content of a page until de-toggled */
-div.admonition.toggle-hidden .admonition-title ~ * {
+.admonition.toggle-hidden .admonition-title ~ * {
     height: 0;
     margin: 0;
     float: left; /* so they overlap when hidden */

--- a/sphinx_togglebutton/_static/togglebutton.css_t
+++ b/sphinx_togglebutton/_static/togglebutton.css_t
@@ -32,6 +32,11 @@ div.admonition.toggle-hidden .admonition-title ~ * {
     position: relative;
 }
 
+/* Clicking the title will toggle the admonition, so a pointer makes this clearer */
+.toggle.admonition .admonition-title {
+    cursor: pointer;
+}
+
 .toggle.admonition.admonition-title:after {
     content: "" !important;
 }

--- a/sphinx_togglebutton/_static/togglebutton.js
+++ b/sphinx_togglebutton/_static/togglebutton.js
@@ -24,15 +24,15 @@ var initToggleItems = () => {
       item.insertAdjacentHTML('beforebegin', collapseButton);
     }
 
-    thisButton = $(`#${buttonID}`);
+    thisButton = document.getElementById(buttonID);
     thisButton.on('click', toggleClickHandler);
     // If the toggleable has a single direct child admonition title,
     // make that clickable also.
-    admonitionTitleSelect = $(`#${toggleID} > .admonition-title`)
-    if (admonitionTitleSelect.length == 1) {
-      admonitionTitleSelect.on('click', toggleClickHandler);
-      admonitionTitleSelect[0].dataset.target = toggleID
-      admonitionTitleSelect[0].dataset.button = buttonID
+    admonitionTitle = document.querySelector(`#${toggleID} > .admonition-title`)
+    if (admonitionTitle) {
+      admonitionTitle.on('click', toggleClickHandler);
+      admonitionTitle[0].dataset.target = toggleID
+      admonitionTitle[0].dataset.button = buttonID
     }
     if (!item.classList.contains("toggle-shown")) {
       toggleHidden(thisButton[0]);

--- a/sphinx_togglebutton/_static/togglebutton.js
+++ b/sphinx_togglebutton/_static/togglebutton.js
@@ -31,8 +31,8 @@ var initToggleItems = () => {
     admonitionTitle = document.querySelector(`#${toggleID} > .admonition-title`)
     if (admonitionTitle) {
       admonitionTitle.on('click', toggleClickHandler);
-      admonitionTitle[0].dataset.target = toggleID
-      admonitionTitle[0].dataset.button = buttonID
+      admonitionTitle.dataset.target = toggleID
+      admonitionTitle.dataset.button = buttonID
     }
     if (!item.classList.contains("toggle-shown")) {
       toggleHidden(thisButton[0]);

--- a/sphinx_togglebutton/_static/togglebutton.js
+++ b/sphinx_togglebutton/_static/togglebutton.js
@@ -26,8 +26,7 @@ var initToggleItems = () => {
 
     thisButton = document.getElementById(buttonID);
     thisButton.on('click', toggleClickHandler);
-    // If the toggleable has a single direct child admonition title,
-    // make that clickable also.
+    // If admonition has a single direct-child title make it clickable.
     admonitionTitle = document.querySelector(`#${toggleID} > .admonition-title`)
     if (admonitionTitle) {
       admonitionTitle.on('click', toggleClickHandler);

--- a/sphinx_togglebutton/_static/togglebutton.js
+++ b/sphinx_togglebutton/_static/togglebutton.js
@@ -26,6 +26,14 @@ var initToggleItems = () => {
 
     thisButton = $(`#${buttonID}`);
     thisButton.on('click', toggleClickHandler);
+    // If the toggleable has a single direct child admonition title,
+    // make that clickable also.
+    admonitionTitleSelect = $(`#${toggleID} > .admonition-title`)
+    if (admonitionTitleSelect.length == 1) {
+      admonitionTitleSelect.on('click', toggleClickHandler);
+      admonitionTitleSelect[0].dataset.target = toggleID
+      admonitionTitleSelect[0].dataset.button = buttonID
+    }
     if (!item.classList.contains("toggle-shown")) {
       toggleHidden(thisButton[0]);
     }


### PR DESCRIPTION
- This was inspired by the discussion in #28, and having a bit of
  spare time and wanting to try something.  This gets the "admonition"
  part of those design ideas.

- In the javascript setup, also configure the whole admonition title
  element to be clickable.  This happens only in the case where it is
  a direct descendent of the admonition box and there is only one
  admonition title descendent.

- This is not designed to be perfect, but is designed to be mostly
  safe with most themes.  It still could cause problems, but it has
  been tested with alabaster, sphinx_book_theme, and sphinx_rtd_theme.

- I don't claim to know javascript or CSS, or have deep knowledge of
  sphinx-togglebutton.  But I do know enough and could read and web
  search enough to see how to add the onclick watcher + data to
  identify the right thing to toggle.

- Suggested reviews:
  - Someone that knows sphinx-togglebutton should see if this makes
    sense.
  - Someone that knows javascript should see if this makes sense
  - It would be prudent for someone else to test (I've tested the
    three themes above and firefox/chrome)
  - But if no one can test the above, it seems fairly safe to me and
    could be released and fixed later.
