### PR TITLE
ENHANCE: Improve hiding behavior for togglebuttons

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -88,6 +88,11 @@ html_theme_options = {
 
 myst_enable_extensions = ["colon_fence"]
 
+# To test behavior in JS
+# togglebutton_hint = "test show"
+# togglebutton_hint_hide = "test hide"
+# togglebutton_open_on_print = False
+
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".

--- a/docs/use.md
+++ b/docs/use.md
@@ -173,5 +173,10 @@ button.toggle-button {
 
 ## Printing behavior with toggle buttons
 
-When you print the screen while using `sphinx-togglebutton`, the toggle-able content and any related UI elements will not show up.
-To reveal it for printing, you must manually un-toggle the items and then print.
+By default `sphinx-togglebutton` will **open all toggle-able content when you print**.
+It will close them again when the printing operation is complete.
+To disable this behavior, use the following configuration in `conf.py`:
+
+```python
+togglebutton_open_on_print = False
+```

--- a/docs/use.md
+++ b/docs/use.md
@@ -173,5 +173,5 @@ button.toggle-button {
 
 ## Printing behavior with toggle buttons
 
-When you print the screen while using `sphinx-togglebutton`, the toggle-able content will not show up.
+When you print the screen while using `sphinx-togglebutton`, the toggle-able content and any related UI elements will not show up.
 To reveal it for printing, you must manually un-toggle the items and then print.

--- a/sphinx_togglebutton/__init__.py
+++ b/sphinx_togglebutton/__init__.py
@@ -15,6 +15,8 @@ def initialize_js_assets(app, config):
     # Update the global context
     app.add_js_file(None, body=f"let toggleHintShow = '{config.togglebutton_hint}';")
     app.add_js_file(None, body=f"let toggleHintHide = '{config.togglebutton_hint_hide}';")
+    open_print = str(config.togglebutton_open_on_print).lower()
+    app.add_js_file(None, body=f"let toggleOpenOnPrint = '{open_print}';")
     app.add_js_file("togglebutton.js")
 
 
@@ -59,6 +61,7 @@ def setup(app):
     app.add_config_value("togglebutton_selector", ".toggle, .admonition.dropdown", "html")
     app.add_config_value("togglebutton_hint", "Click to show", "html")
     app.add_config_value("togglebutton_hint_hide", "Click to hide", "html")
+    app.add_config_value("togglebutton_open_on_print", True, "html")
 
     # Run the function after the builder is initialized
     app.connect("builder-inited", insert_custom_selection_config)

--- a/sphinx_togglebutton/_static/togglebutton.css
+++ b/sphinx_togglebutton/_static/togglebutton.css
@@ -21,6 +21,8 @@
 }
 
 /* hides all the content of a page until de-toggled */
+/* this doesn't apply when printing */
+
 .toggle-hidden.admonition .admonition-title ~ * {
     height: 0;
     margin: 0;
@@ -53,10 +55,7 @@ button.toggle-button {
 @media (min-width: 768px) {
     button.toggle-button.toggle-button-hidden:before {
         content: attr(data-toggle-hint);  /* This will be filled in by JS */
-        position: absolute;
         font-size: .8em;
-        left: -6.5em;
-        bottom: .4em;
     }
 }
 
@@ -118,16 +117,8 @@ details.toggle-details[open] summary ~ * {
 
 /* Print rules - we hide all toggle button elements at print */
 @media print {
-    .toggle-hidden.admonition {
-      display: none;
-    }
-
-    details.toggle-details:not([open]) {
-        display: none;
-    }
-
     /* Always hide the summary so the button doesn't show up */
     details.toggle-details summary {
         display: none;
     }
-  }
+}

--- a/sphinx_togglebutton/_static/togglebutton.css
+++ b/sphinx_togglebutton/_static/togglebutton.css
@@ -115,3 +115,19 @@ details.toggle-details[open] summary ~ * {
   from {opacity: 0%;}
   to {opacity: 100%;}
 }
+
+/* Print rules - we hide all toggle button elements at print */
+@media print {
+    .toggle-hidden.admonition {
+      display: none;
+    }
+
+    details.toggle-details:not([open]) {
+        display: none;
+    }
+
+    /* Always hide the summary so the button doesn't show up */
+    details.toggle-details summary {
+        display: none;
+    }
+  }

--- a/sphinx_togglebutton/_static/togglebutton.css
+++ b/sphinx_togglebutton/_static/togglebutton.css
@@ -7,8 +7,6 @@
     transition: opacity .3s, height .3s;
 }
 
-/* Overrides for admonition toggles */
-
 /* Toggle buttons inside admonitions so we see the title */
 .toggle.admonition {
     position: relative;
@@ -21,8 +19,6 @@
 }
 
 /* hides all the content of a page until de-toggled */
-/* this doesn't apply when printing */
-
 .toggle-hidden.admonition .admonition-title ~ * {
     height: 0;
     margin: 0;
@@ -56,6 +52,7 @@ button.toggle-button {
     button.toggle-button.toggle-button-hidden:before {
         content: attr(data-toggle-hint);  /* This will be filled in by JS */
         font-size: .8em;
+        align-self: center;
     }
 }
 
@@ -90,12 +87,21 @@ details.toggle-details summary {
     display: flex;
     align-items: center;
     width: fit-content;
+    cursor: pointer;
     list-style: none;
     border-radius: .4em;
     border: 1px solid #ccc;
     background: #f8f8f8;
     padding: 0.4em 1em 0.4em 0.5em; /* Less padding on left because the SVG has left margin */
     font-size: .9em;
+}
+
+details.toggle-details summary:hover {
+    background: #f6f6f6;
+}
+
+details.toggle-details summary:active {
+    background: #eee;
 }
 
 details.toggle-details[open] summary {

--- a/sphinx_togglebutton/_static/togglebutton.js
+++ b/sphinx_togglebutton/_static/togglebutton.js
@@ -137,3 +137,36 @@ const sphinxToggleRunWhenDOMLoaded = cb => {
 }
 sphinxToggleRunWhenDOMLoaded(addToggleToSelector)
 sphinxToggleRunWhenDOMLoaded(initToggleItems)
+
+/** Toggle details blocks to be open when printing */
+if (toggleOpenOnPrint == "true") {
+  window.addEventListener("beforeprint", () => {
+    // Open the details
+    document.querySelectorAll("details.toggle-details").forEach((el) => {
+      el.dataset["togglestatus"] = el.open;
+      el.open = true;
+    });
+  
+    // Open the admonitions
+    document.querySelectorAll(".admonition.toggle.toggle-hidden").forEach((el) => {
+      console.log(el);
+      el.querySelector("button.toggle-button").click();
+      el.dataset["toggle_after_print"] = "true";
+    });
+  });
+  window.addEventListener("afterprint", () => {
+    // Re-close the details that were closed
+    document.querySelectorAll("details.toggle-details").forEach((el) => {
+      el.open = el.dataset["togglestatus"] == "true";
+      delete el.dataset["togglestatus"];
+    });
+  
+    // Re-close the admonition toggle buttons
+    document.querySelectorAll(".admonition.toggle").forEach((el) => {
+      if (el.dataset["toggle_after_print"] == "true") {
+        el.querySelector("button.toggle-button").click();
+        delete el.dataset["toggle_after_print"];
+      }
+    });
+  });
+}


### PR DESCRIPTION
This updates our CSS to make the toggle buttons have more reasonable defaults when hiding. Here is the logic we follow:

- ~Any toggle buttons with *hidden content* will not show up in the printed page.~
- ~Any toggle buttons with *shown content* will show their content, but not the toggle buttons themselves.~

UPDATE: The latest commit updates the behavior to the following:

- When print happens, a little JS is triggered to search for any closed `details` toggles, and any closed `.admonition` toggles
- It opens them, and stores a data attribute to note that they've been opened for print
- After print, it re-searches for these elements again, closes them, and deletes the data attribute
- This is configurable by a new config option `togglebutton_open_on_print` (default `True`)

closes #14 