### PR TITLE
ENH: Vertical flip for toggle icon

### DIFF
--- a/sphinx_togglebutton/_static/togglebutton.css
+++ b/sphinx_togglebutton/_static/togglebutton.css
@@ -75,7 +75,7 @@ button.toggle-button {
     transform: rotate(-90deg) scaleX(-1);
 }
 
-/* With details toggles, we don't rotate the icon so it point sright */
+/* With details toggles, we don't rotate the icon so it points right */
 details.toggle-details .tb-icon {
     height: 1.4em;
     width: 1.4em;

--- a/sphinx_togglebutton/_static/togglebutton.css
+++ b/sphinx_togglebutton/_static/togglebutton.css
@@ -64,15 +64,24 @@ button.toggle-button {
     stroke: currentColor;  /* So that we inherit the color of other text */
 }
 
+/* Rotate icon with admonitions so that it points down */
+.admonition.toggle .tb-icon {
+    transform: rotate(-90deg);
+}
+
+/* When the admonition is hidden, icon should flip upwards but retain rotation */
+/* We scaleX, in order to flip along Y, because it is rotated */
+.admonition.toggle .toggle-button-hidden .tb-icon {
+    transform: rotate(-90deg) scaleX(-1);
+}
+
+/* With details toggles, we don't rotate the icon so it point sright */
 details.toggle-details .tb-icon {
     height: 1.4em;
     width: 1.4em;
     margin-top: 0.1em;  /* To center the button vertically */
 }
 
-.toggle-button-hidden .tb-icon {
-    transform: rotate(90deg);
-}
 
 /**
  * Details-based toggles.


### PR DESCRIPTION
OK @psychemedia you nerd sniped me 😅

This is a minor CSS change to make the admonition toggle "flip" instead of rotate.

Would be great to have feedback - does this seem more intuitive?

closes #38 