### PR TITLE
Fix insertion of toggle hint into nested spans

### DIFF
--- a/sphinx_togglebutton/_static/togglebutton.js
+++ b/sphinx_togglebutton/_static/togglebutton.js
@@ -73,9 +73,9 @@ var initToggleItems = () => {
         }
         // Update the inner text for the proper hint
         if (details.open) {
-          summary.querySelector("span[class=toggle-details__summary-text]").innerText = toggleHintShow;
+          summary.querySelector("span.toggle-details__summary-text").innerText = toggleHintShow;
         } else {
-          summary.querySelector("span[class=toggle-details__summary-text]").innerText = toggleHintHide;
+          summary.querySelector("span.toggle-details__summary-text").innerText = toggleHintHide;
         }
         
       });


### PR DESCRIPTION
Possible fix for #44 

This commit makes the query changing the text of the toggle button more specific
to not insert the hint in unrelated spans that are nested in the toggleable region