### PR TITLE
docs/use: Also document `toggle-shown`

### DIFF
--- a/docs/use.md
+++ b/docs/use.md
@@ -75,6 +75,8 @@ A note!
 A warning!
 :::
 
+If you add the class `toggle-shown`, it will be un-toggled by default but collapsable (`:class: dropdown, toggle-shown`).
+
 
 (toggle-directive)=
 ## Use the `{toggle}` directive to toggle blocks of content


### PR DESCRIPTION
- This is not shown anywhere except the readme, and I just spent more than a short time looking for this option, so adding it to save everyone time.  I haven't tried hard to keep it organized, but git grep says that `toggle-shown` is not anywhere in docs/.