### PR TITLE
Fix dropdown toggle height when closed

### DIFF
--- a/sphinx_togglebutton/_static/togglebutton.css
+++ b/sphinx_togglebutton/_static/togglebutton.css
@@ -43,6 +43,7 @@
     margin: 0;
     opacity: 0;
     visibility: hidden;
+    display: block;
 }
 
 /* General button style and position*/


### PR DESCRIPTION
This fixes a bug where the inline images do not take a height of zero override unless they are of `display: block`.

This is the test site:
https://phispel.github.io/dropdown-height-bug/notebooks.html

![css-dropdown-bug](https://github.com/executablebooks/sphinx-togglebutton/assets/913249/b06ea93a-92cb-4b2e-833d-d02e4dfe32fc)

See issue: https://github.com/executablebooks/jupyter-book/issues/1928

