### PR TITLE
Display hide hint text when admonition is expanded

### DIFF
--- a/sphinx_togglebutton/_static/togglebutton.css
+++ b/sphinx_togglebutton/_static/togglebutton.css
@@ -66,7 +66,7 @@ button.toggle-button {
 
 /* Display the toggle hint on wide screens */
 @media (min-width: 768px) {
-    button.toggle-button.toggle-button-hidden:before {
+    button.toggle-button:before {
         content: attr(data-toggle-hint);  /* This will be filled in by JS */
         font-size: .8em;
         align-self: center;

--- a/sphinx_togglebutton/_static/togglebutton.js
+++ b/sphinx_togglebutton/_static/togglebutton.js
@@ -100,9 +100,11 @@ var toggleHidden = (button) => {
   if (itemToToggle.classList.contains("toggle-hidden")) {
     itemToToggle.classList.remove("toggle-hidden");
     button.classList.remove("toggle-button-hidden");
+    button.dataset.toggleHint = toggleHintHide;
   } else {
     itemToToggle.classList.add("toggle-hidden");
     button.classList.add("toggle-button-hidden");
+    button.dataset.toggleHint = toggleHintShow;
   }
 }
 


### PR DESCRIPTION
There is a puzzling inconsistency between the toggle button created with the `toggle` directive, versus one created via an `admonition`.

For the toggle-directive button, you click "Click to show", the widget expands, and the text is replaced with "Click to hide".

But for the admonition-directive button, you click "Click to show", the widget expands, and the text goes away.

You can corroborate this behavior at the [docs](https://sphinx-togglebutton.readthedocs.io/en/latest/index.html).

This PR makes the admonition behavior match the toggle-directive behavior.