### PR TITLE
Fix dropdown under a code cell in dark mode

### DIFF
--- a/sphinx_togglebutton/_static/togglebutton.css
+++ b/sphinx_togglebutton/_static/togglebutton.css
@@ -159,3 +159,8 @@ details.toggle-details[open] summary ~ * {
         display: none;
     }
 }
+
+/* Dropdown under a code cell in dark mode */
+[data-theme="dark"] details.hide.below-input summary span {
+  color: black !important;
+}


### PR DESCRIPTION
With fix (from [here](https://pipefunc.readthedocs.io/en/latest/concepts/cli/)):

<img width="815" alt="image" src="https://github.com/user-attachments/assets/b54b6e8b-fde8-47f1-b94d-793af05e3f58" />


Without fix ([from sphinx-togglebutton](https://sphinx-togglebutton.readthedocs.io/en/latest/reference/notebooks.html) docs):
<img width="815" alt="image" src="https://github.com/user-attachments/assets/c5ff916d-f6b7-4807-9bcc-4ab5f666bb39" />

