### PR TITLE
docs: fix the 404/not found when using "Suggest edit" button

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,6 +27,8 @@ html_theme = "sphinx_book_theme"
 
 html_theme_options = {
     "repository_url": "https://github.com/executablebooks/sphinx-togglebutton",
+    "path_to_docs": "docs",
+    "repository_branch": "master",
     "use_repository_button": True,
     "use_issues_button": True,
     "use_edit_page_button": True,


### PR DESCRIPTION
Adds repository options to `html_theme_options` to link to in-use branch and path in the repository containing the docs.  Fixes `Suggest edit` button link.

Ref: https://sphinx-book-theme.readthedocs.io/en/latest/reference.html