### PR TITLE
Fix selector for admonition title in togglebutton.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.5 - 2026-03-27
+
+### Fixed
+
+- Fix selector for admonition title in togglebutton.js.
+
 ## 0.4.4 - 2026-01-14
 
 ### Fixed

--- a/sphinx_togglebutton/_static/togglebutton.js
+++ b/sphinx_togglebutton/_static/togglebutton.js
@@ -50,7 +50,7 @@ var initToggleItems = () => {
 
       // Add click handlers for the button + admonition title (if admonition)
       admonitionTitle = document.querySelector(
-        `#${toggleID} > .admonition-title`
+        `#` + CSS.escape(toggleID) + ` > .admonition-title`
       );
       if (admonitionTitle) {
         // If an admonition, then make the whole title block clickable


### PR DESCRIPTION
When the toggleID contains symbols such as `:` an error occurs in JS and all dropdown admonitions after the current element stop functioning.

The `CSS.escape` call fixes this.